### PR TITLE
456 AMS Restore, SSL, and Amazon Linux 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ running the AMS web app.
          may change, so be sure to consult with developers if you are unsure
          which branch/commit represents the latest code.
       1. Add an optional description.
-      1.
 
 ## Restore AWS stack using data from snapshot backups
 
@@ -75,4 +74,64 @@ to the point-in-time that the snapshots were taken.
 
 ### Steps
 
-1.
+1. Make sure you have the latest version of `ams.restore_from_backups.json` from this
+   repository saved to your local machine.
+1. Log into AWS Management Console.
+1. Navigate to RDS
+1. Click on "DB Instances"
+1. Create snapshots of the MySQL RDS instances for Rails and Fedora by clicking on "Actions" >> "Take Snapshot"
+   1. Copy the Amazon Resource Names (ARNs).
+   1. Edit your local version of `ams.restore_from_backups.json`
+      1. Enter the Rails DB ARN where it says: "REPLACE WITH ARN OF RAILS RDS DB SNAPSHOT"
+      1. Enter the Fedora DB ARN where it says: "REPLACE WITH ARN OF FEDORA RDS DB SNAPSHOT"
+1. Navigate to EC2
+1. Select the EC2 instance for Fedora
+1. Click on "Actions" >> "Image and templates" >> "Create Image"
+   1. Defaults are fine.
+   1. Click on "Create Image"
+   1. Copy the AMI ID from the success message (should look like: ami-xxxxxxxxxxxxxxxxx)
+      1. You can also get it from the EC2 interface by clicking on AMIs and finding it by AMI Name
+   1. Edit your local version of ams.restore_from_backups.json
+      1. Enter the AMI ID where it says: "REPLACE WITH IMAGE ID OF AMI CREATED FROM SNAPSHOT OF DataInstance EC2 ROOT VOLUME"
+1. Navigate to CloudFormation.
+1. Click "Create stack" >> "With new resources".
+1. Under "Prerequisite - Prepare template" select "Template is ready".
+1. Under "Specify template" select "Upload a template file".
+1. Click "Choose File" and select your local copy of `ams.restore_from_backups.json` from
+   step 1, and then click "Next".
+1. Enter a **Stack Name**, enter values for the parameters:
+   1. All password fields are required.
+   1. All other default values should work, but you can adjust them as needed.
+   1. Click "Next" when finished.
+1. For the "Configure stack options" and "Advanced options", defaults will
+   suffice, but adjust as needed, and click "Next" when finished.
+1. Review the stack details to make sure it's what you want. To go back, click
+   the "Previous" button at the bottom.
+1. If the stack looks good to go, check the checkbox labeled with
+   "I acknowledge that AWS CloudFormation might create IAM resources."
+1. Click "Create Stack". This will kick of an asynchronous process to build
+   the stack. Check the "Events" tab to see the progress. When you see an event
+   in the list whose "Logical ID" is your stack name, and the "Status" is
+   "CREATE_COMPLETE", then the stack is ready.
+1. Deploy Code
+   1. In the AWS Management console, navigate to CodeDeploy.
+   1. In the left menu, click "Applications".
+   1. Click the AWS "Application" that was created with the CloudFormation
+      template (it should be named the same as your stack).
+   1. Click deployment group for the app (there should be only 1 and be named
+      the same as the stack name, but with "-DG" suffix appended.
+   1. Click the "Create Deployment" button.
+   1. On the "Create Deployment" screen:
+      1. Enter the deployment group that was created as part of the stack. It
+         should be named the same as the stack, with a "-DG" suffix.
+      1. Select the "My application is stored in Github" option.
+      1. Enter the Github token name: 'jasoncorum'. (NOTE: if this stops
+         working, we can connect another Github account).
+      1. Enter the repository name: "wgbh-mla/ams".
+      1. Enter the commit hash of the commit you want to deploy. **NOTE:
+         Due to a branching convention we never truly followed, we do not
+         currently use the `master` branch, but rather the the `develop` branch,
+         thus we typically deploy the most recent commit from `develop`. This
+         may change, so be sure to consult with developers if you are unsure
+         which branch/commit represents the latest code.
+      1. Add an optional description.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ running the AMS web app.
    step 1, and then click "Next".
 1. Enter a **Stack Name**, enter values for the parameters:
    1. All password fields are required.
+   1. ServerName is used for enabling HTTPS and should match the site's domain for verification. If not enabling HTTPS, the default value is fine.
    1. All other default values should work, but you can adjust them as needed.
    1. Click "Next" when finished.
 1. For the "Configure stack options" and "Advanced options", defaults will
@@ -101,6 +102,7 @@ to the point-in-time that the snapshots were taken.
    step 1, and then click "Next".
 1. Enter a **Stack Name**, enter values for the parameters:
    1. All password fields are required.
+   1. ServerName is used for enabling HTTPS and should match the site's domain for verification. If not enabling HTTPS, the default value is fine.
    1. All other default values should work, but you can adjust them as needed.
    1. Click "Next" when finished.
 1. For the "Configure stack options" and "Advanced options", defaults will
@@ -135,3 +137,13 @@ to the point-in-time that the snapshots were taken.
          may change, so be sure to consult with developers if you are unsure
          which branch/commit represents the latest code.
       1. Add an optional description.
+
+### SSL
+
+The Cloudformation template includes setup that prepares the AMS web server for encryption with Certbot. As you are creating a new stack or restoring from the old do the following:
+
+1. As you are setting the Parameters when launching a stack from a Cloudformation template, set the ServerName so that it matches the domain of your site.
+1. Creating the stack via the Cloudformation template.
+1. Deploy the code via CodeDeploy.
+1. SSH to the web server.
+1. Run `sudo certbot` to get the certificate.

--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ running the AMS web app.
       1. Enter the deployment group that was created as part of the stack. It
          should be named the same as the stack, with a "-DG" suffix.
       1. Select the "My application is stored in Github" option.
-      1. Enter the Github token name: 'jasoncorum'. (NOTE: if this stops
-         working, we can connect another Github account).
+      1. Enter the Github token name.
       1. Enter the repository name: "wgbh-mla/ams".
       1. Enter the commit hash of the commit you want to deploy. **NOTE:
          Due to a branching convention we never truly followed, we do not
@@ -75,14 +74,17 @@ to the point-in-time that the snapshots were taken.
 
 ### Steps
 
-1. Make sure you have the latest version of `ams.restore_from_backups.json` from this
+1. Make sure you have the latest version of `ams.restore_from_snapshot.json` from this
    repository saved to your local machine.
+1. If you're recreating from an existing instance, ssh in to the active EC2 instance hosting Solr and Fedora to copy their data directories.
+  1. The Fedora data directory is currently located at: /mnt/fedora-data
+  1. The Solr data directory is currently located at: /var/solr/data/ams/data
 1. Log into AWS Management Console.
 1. Navigate to RDS
 1. Click on "DB Instances"
 1. Create snapshots of the MySQL RDS instances for Rails and Fedora by clicking on "Actions" >> "Take Snapshot"
    1. Copy the Amazon Resource Names (ARNs).
-   1. Edit your local version of `ams.restore_from_backups.json`
+   1. Edit your local version of `ams.restore_from_snapshot.json`
       1. Enter the Rails DB ARN where it says: "REPLACE WITH ARN OF RAILS RDS DB SNAPSHOT"
       1. Enter the Fedora DB ARN where it says: "REPLACE WITH ARN OF FEDORA RDS DB SNAPSHOT"
 1. Navigate to EC2
@@ -127,8 +129,7 @@ to the point-in-time that the snapshots were taken.
       1. Enter the deployment group that was created as part of the stack. It
          should be named the same as the stack, with a "-DG" suffix.
       1. Select the "My application is stored in Github" option.
-      1. Enter the Github token name: 'jasoncorum'. (NOTE: if this stops
-         working, we can connect another Github account).
+      1. Enter the Github token name.
       1. Enter the repository name: "wgbh-mla/ams".
       1. Enter the commit hash of the commit you want to deploy. **NOTE:
          Due to a branching convention we never truly followed, we do not

--- a/ams.new_app.json
+++ b/ams.new_app.json
@@ -641,9 +641,9 @@
         },
         "AWSRegionArch2AMI": {
             "us-east-1": {
-                "PV64": "ami-2a69aa47",
-                "HVM64": "ami-97785bed",
-                "HVMG2": "ami-0a6e3770"
+                "PV64": "ami-036de34578cbfa625",
+                "HVM64": "ami-047a51fa27710816e",
+                "HVMG2": "ami-087435bc474caa2c4"
             },
             "us-west-2": {
                 "PV64": "ami-7f77b31f",
@@ -843,7 +843,7 @@
                     "Ref": "RDSMYSQLInstanceClass"
                 },
                 "Engine": "MySQL",
-                "EngineVersion": "5.5",
+                "EngineVersion": "5.7",
                 "DBSubnetGroupName": {
                     "Ref": "MyDBSubnetGroup"
                 },
@@ -873,7 +873,7 @@
                     "Ref": "FedoraRDSMYSQLInstanceClass"
                 },
                 "Engine": "MySQL",
-                "EngineVersion": "5.5",
+                "EngineVersion": "5.7",
                 "DBSubnetGroupName": {
                     "Ref": "MyDBSubnetGroup"
                 },
@@ -1063,18 +1063,18 @@
                                 "yum -y install mysql-devel\n",
                                 "\n",
                                 "#Install Fedora\n",
-                                "yum -y install tomcat7\n",
+                                "yum -y install tomcat\n",
                                 "echo 'JAVA_OPTS=\"${JAVA_OPTS} -Dfcrepo.home=/mnt/fedora-data\"' >> /etc/sysconfig/tomcat7\n",
                                 "mkdir /mnt/fedora-data\n",
                                 "chown tomcat:tomcat /mnt/fedora-data/\n",
                                 "wget https://github.com/fcrepo4/fcrepo4/releases/download/fcrepo-4.7.5/fcrepo-webapp-4.7.5.war\n",
-                                "cp fcrepo-webapp-4.7.5.war /var/lib/tomcat7/webapps/\n",
-                                "echo 'fcrepo.home=/mnt/fedora-data' >> /etc/tomcat7/catalina.properties\n",
-                                "echo 'fcrepo.mysql.host=", { "Fn::GetAtt": ["FedoraRDSDB", "Endpoint.Address" ] },"' >> /etc/tomcat7/catalina.properties\n",
-                                "echo 'fcrepo.mysql.username=", { "Ref": "FedoraDBUser" }, "' >> /etc/tomcat7/catalina.properties\n",
-                                "echo 'fcrepo.mysql.password=", { "Ref": "FedoraDBPassword" }, "' >> /etc/tomcat7/catalina.properties\n",
-                                "echo 'fcrepo.modeshape.configuration=file:/var/lib/tomcat7/webapps/fcrepo-webapp-4.7.5/WEB-INF/classes/config/jdbc-mysql/repository.json' >> /etc/tomcat7/catalina.properties\n",
-                                "service tomcat7 restart\n",
+                                "cp fcrepo-webapp-4.7.5.war /var/lib/tomcat/webapps/\n",
+                                "echo 'fcrepo.home=/mnt/fedora-data' >> /etc/tomcat/catalina.properties\n",
+                                "echo 'fcrepo.mysql.host=", { "Fn::GetAtt": ["FedoraRDSDB", "Endpoint.Address" ] },"' >> /etc/tomcat/catalina.properties\n",
+                                "echo 'fcrepo.mysql.username=", { "Ref": "FedoraDBUser" }, "' >> /etc/tomcat/catalina.properties\n",
+                                "echo 'fcrepo.mysql.password=", { "Ref": "FedoraDBPassword" }, "' >> /etc/tomcat/catalina.properties\n",
+                                "echo 'fcrepo.modeshape.configuration=file:/var/lib/tomcat/webapps/fcrepo-webapp-4.7.5/WEB-INF/classes/config/jdbc-mysql/repository.json' >> /etc/tomcat/catalina.properties\n",
+                                "service tomcat restart\n",
                                 "wget http://archive.apache.org/dist/lucene/solr/6.5.0/solr-6.5.0.tgz\n",
                                 "tar xzf solr-6.5.0.tgz solr-6.5.0/bin/install_solr_service.sh --strip-components=2\n",
                                 "./install_solr_service.sh solr-6.5.0.tgz\n",
@@ -1096,7 +1096,7 @@
                                 },
                                 "/opt/solr/bin/init.d/solr restart\n",
                                 "\n",
-                                "chkconfig tomcat7 on\n",
+                                "chkconfig tomcat on\n",
                                 "chkconfig solr on\n",
                                 "/opt/aws/bin/cfn-signal -e 0",
                                 "\n"
@@ -1267,7 +1267,7 @@
                                 "echo 'export PATH=$PATH:/opt/fits-1.0.5/' >> /etc/profile\n",
                                 "#Install Apache\n",
                                 "yum install -y curl-devel nano sqlite-devel libyaml-devel   \n",
-                                "yum install -y httpd24 httpd24-devel\n",
+                                "yum install -y httpd httpd-devel links\n",
                                 "su - ec2-user -c 'gem install passenger'\n",
                                 "su - ec2-user -c 'passenger-install-apache2-module --auto'\n",
                                 "su - ec2-user -c 'passenger-install-apache2-module --snippet > /tmp/passenger.conf'\n",
@@ -1432,6 +1432,150 @@
                                 "\n",
                                 "    # Tell Apache and Passenger where your apps public directory is\n",
                                 "    DocumentRoot /var/www/ams/public\n",
+<<<<<<< HEAD:ams.new_app.json
+=======
+                                {
+                                    "Fn::Join": [
+                                        " ",
+                                        [
+                                            "SetEnv",
+                                            "RAILS_ENV",
+                                            {
+                                                "Ref": "Environment"
+                                            },
+                                            "\n"
+                                        ]
+                                    ]
+                                },
+                                {
+                                    "Fn::Join": [
+                                        " ",
+                                        [
+                                            "SetEnv",
+                                            "DB_HOST",
+                                            {
+                                                "Fn::GetAtt": [
+                                                    "RDSDB",
+                                                    "Endpoint.Address"
+                                                ]
+                                            },
+                                            "\n"
+                                        ]
+                                    ]
+                                },
+                                {
+                                    "Fn::Join": [
+                                        " ",
+                                        [
+                                            "SetEnv",
+                                            "DB_NAME",
+                                            {
+                                                "Ref": "DBName"
+                                            },
+                                            "\n"
+                                        ]
+                                    ]
+                                },
+                                {
+                                    "Fn::Join": [
+                                        " ",
+                                        [
+                                            "SetEnv",
+                                            "DB_USER",
+                                            {
+                                                "Ref": "DBUser"
+                                            },
+                                            "\n"
+                                        ]
+                                    ]
+                                },
+                                {
+                                    "Fn::Join": [
+                                        " ",
+                                        [
+                                            "SetEnv",
+                                            "DB_PWD",
+                                            {
+                                                "Ref": "DBPassword"
+                                            },
+                                            "\n"
+                                        ]
+                                    ]
+                                },
+                                {
+                                    "Fn::Join": [
+                                        " ",
+                                        [
+                                            "SetEnv",
+                                            "SOLR_URL",
+                                            {
+                                                "Fn::Join": [
+                                                    "",
+                                                    [
+                                                        "\"",
+                                                        "http://",
+                                                        {
+                                                            "Fn::GetAtt": [
+                                                                "DataInstance",
+                                                                "PublicDnsName"
+                                                            ]
+                                                        },
+                                                        ":8983/solr/",
+                                                        {
+                                                            "Ref": "SolrCoreName"
+                                                        },
+                                                        "\""
+                                                    ]
+                                                ]
+                                            },
+                                            "\n"
+                                        ]
+                                    ]
+                                },
+                                {
+                                    "Fn::Join": [
+                                        " ",
+                                        [
+                                            "SetEnv",
+                                            "FCREPO_URL",
+                                            {
+                                                "Fn::Join": [
+                                                    "",
+                                                    [
+                                                        "\"",
+                                                        "http://",
+                                                        {
+                                                            "Fn::GetAtt": [
+                                                                "DataInstance",
+                                                                "PublicDnsName"
+                                                            ]
+                                                        },
+                                                        ":8080/fcrepo-webapp-4.7.5/rest",
+                                                        "\""
+                                                    ]
+                                                ]
+                                            },
+                                            "\n"
+                                        ]
+                                    ]
+                                },
+                                {
+                                    "Fn::Join": [
+                                        " ",
+                                        [
+                                            "SetEnv",
+                                            "REDIS_SERVER",
+                                            {
+                                                "Fn::GetAtt": [
+                                                    "RedisCluster",
+                                                    "RedisEndpoint.Address"
+                                                ]
+                                            },
+                                            "\n"
+                                        ]
+                                    ]
+                                },
+>>>>>>> Upgrade to Amazon Linux 2 and set up for SSL:ams_base.json
                                 "\n",
                                 "    # Relax Apache security settings\n",
                                 "    <Directory /var/www/ams/public>\n",
@@ -1445,10 +1589,21 @@
                                 "\n",
                                 "#Configure Apache\n",
                                 "usermod -a -G apache ec2-user\n",
-                                "service httpd restart\n",
+                                "systemctl restart httpd\n",
                                 "\n",
                                 "chkconfig httpd on\n",
                                 "\n",
+                                "#Prepare SSL\n",
+                                "yum install -y mod_ssl\n",
+                                "cd /etc/pki/tls/certs\n",
+                                "./make-dummy-cert localhost.crt\n",
+                                "sed -e '/SSLCertificateKeyFile/s/^#*/#/' -i /etc/httpd/conf.d/ssl.conf\n",
+                                "systemctl restart httpd\n",
+                                "cd /home/ec2-user\n",
+                                "wget -r --no-parent -A 'epel-release-*.rpm' https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/e/\n",
+                                "rpm -Uvh dl.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-*.rpm\n",
+                                "yum-config-manager --enable epel*\n",
+                                "yum install -y certbot python2-certbot-apache\n",
                                 "#Install code deploy\n",
                                 "mkdir /tmp/codedeploy\n",
                                 "cd /tmp/codedeploy\n",
@@ -1855,6 +2010,12 @@
                         "IpProtocol": "tcp",
                         "FromPort": "80",
                         "ToPort": "80",
+                        "CidrIp": "0.0.0.0/0"
+                    },
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": "443",
+                        "ToPort": "443",
                         "CidrIp": "0.0.0.0/0"
                     },
                     {

--- a/ams.new_app.json
+++ b/ams.new_app.json
@@ -56,20 +56,6 @@
             ],
             "ConstraintDescription": "must select a valid Redis Cache Node type."
         },
-        "RDSMYSQLInstanceClass": {
-            "Default": "db.t2.small",
-            "Description": "The database instance type",
-            "Type": "String",
-            "AllowedValues": [
-                "db.t2.small",
-                "db.t2.medium",
-                "db.m1.small",
-                "db.m1.large",
-                "db.m4.xlarge",
-                "db.m4.4xlarge",
-            ],
-            "ConstraintDescription": "must contain only alphanumeric characters."
-        },
         "RDSMYSQLStorage": {
             "Default": "20",
             "Description": "The size of the database (Gb)",
@@ -103,21 +89,6 @@
             "MinLength": "1",
             "MaxLength": "41",
             "AllowedPattern": "[a-zA-Z0-9]*",
-            "ConstraintDescription": "must contain only alphanumeric characters."
-        },
-        "FedoraRDSMYSQLInstanceClass": {
-            "Default": "db.t2.small",
-            "Description": "The Fedora database instance type",
-            "Type": "String",
-            "AllowedValues": [
-                "db.t2.small",
-                "db.t2.medium",
-                "db.m1.small",
-                "db.m4.large",
-                "db.m4.xlarge",
-                "db.m4.2xlarge",
-                "db.m4.4xlarge"
-            ],
             "ConstraintDescription": "must contain only alphanumeric characters."
         },
         "FedoraRDSMYSQLStorage": {
@@ -154,136 +125,12 @@
             "MaxLength": "41",
             "ConstraintDescription": "must contain only alphanumeric characters, underscores, or dashes."
         },
-        "WebInstanceType": {
-            "Description": "WebServer EC2 instance type",
-            "Type": "String",
-            "Default": "t2.medium",
-            "AllowedValues": [
-                "t1.micro",
-                "t2.nano",
-                "t2.micro",
-                "t2.small",
-                "t2.medium",
-                "t2.large",
-                "m1.small",
-                "m1.medium",
-                "m1.large",
-                "m1.xlarge",
-                "m2.xlarge",
-                "m2.2xlarge",
-                "m2.4xlarge",
-                "m3.medium",
-                "m3.large",
-                "m3.xlarge",
-                "m3.2xlarge",
-                "m4.large",
-                "m4.xlarge",
-                "m4.2xlarge",
-                "m4.4xlarge",
-                "m4.10xlarge",
-                "c1.medium",
-                "c1.xlarge",
-                "c3.large",
-                "c3.xlarge",
-                "c3.2xlarge",
-                "c3.4xlarge",
-                "c3.8xlarge",
-                "c4.large",
-                "c4.xlarge",
-                "c4.2xlarge",
-                "c4.4xlarge",
-                "c4.8xlarge",
-                "g2.2xlarge",
-                "g2.8xlarge",
-                "r3.large",
-                "r3.xlarge",
-                "r3.2xlarge",
-                "r3.4xlarge",
-                "r3.8xlarge",
-                "i2.xlarge",
-                "i2.2xlarge",
-                "i2.4xlarge",
-                "i2.8xlarge",
-                "d2.xlarge",
-                "d2.2xlarge",
-                "d2.4xlarge",
-                "d2.8xlarge",
-                "hi1.4xlarge",
-                "hs1.8xlarge",
-                "cr1.8xlarge",
-                "cc2.8xlarge",
-                "cg1.4xlarge"
-            ],
-            "ConstraintDescription": "must be a valid EC2 instance type."
-        },
         "WebInstanceVolumeSize": {
             "Description": "Size of the EBS volume if attached",
             "Type": "Number",
             "Default": "8",
             "MinValue": "1",
             "MaxValue": "1000"
-        },
-        "DataInstanceType": {
-            "Description": "Data EC2 instance type",
-            "Type": "String",
-            "Default": "t2.medium",
-            "AllowedValues": [
-                "t1.micro",
-                "t2.nano",
-                "t2.micro",
-                "t2.small",
-                "t2.medium",
-                "t2.large",
-                "m1.small",
-                "m1.medium",
-                "m1.large",
-                "m1.xlarge",
-                "m2.xlarge",
-                "m2.2xlarge",
-                "m2.4xlarge",
-                "m3.medium",
-                "m3.large",
-                "m3.xlarge",
-                "m3.2xlarge",
-                "m4.large",
-                "m4.xlarge",
-                "m4.2xlarge",
-                "m4.4xlarge",
-                "m4.10xlarge",
-                "c1.medium",
-                "c1.xlarge",
-                "c3.large",
-                "c3.xlarge",
-                "c3.2xlarge",
-                "c3.4xlarge",
-                "c3.8xlarge",
-                "c4.large",
-                "c4.xlarge",
-                "c4.2xlarge",
-                "c4.4xlarge",
-                "c4.8xlarge",
-                "g2.2xlarge",
-                "g2.8xlarge",
-                "r3.large",
-                "r3.xlarge",
-                "r3.2xlarge",
-                "r3.4xlarge",
-                "r3.8xlarge",
-                "i2.xlarge",
-                "i2.2xlarge",
-                "i2.4xlarge",
-                "i2.8xlarge",
-                "d2.xlarge",
-                "d2.2xlarge",
-                "d2.4xlarge",
-                "d2.8xlarge",
-                "hi1.4xlarge",
-                "hs1.8xlarge",
-                "cr1.8xlarge",
-                "cc2.8xlarge",
-                "cg1.4xlarge"
-            ],
-            "ConstraintDescription": "must be a valid EC2 instance type."
         },
         "DataInstanceVolumeSize": {
             "Description": "Size of the EBS volume if attached",
@@ -308,167 +155,6 @@
         },
     },
     "Mappings": {
-        "AWSInstanceType2Arch": {
-            "t1.micro": {
-                "Arch": "PV64"
-            },
-            "t2.nano": {
-                "Arch": "HVM64"
-            },
-            "t2.micro": {
-                "Arch": "HVM64"
-            },
-            "t2.small": {
-                "Arch": "HVM64"
-            },
-            "t2.medium": {
-                "Arch": "HVM64"
-            },
-            "t2.large": {
-                "Arch": "HVM64"
-            },
-            "m1.small": {
-                "Arch": "PV64"
-            },
-            "m1.medium": {
-                "Arch": "PV64"
-            },
-            "m1.large": {
-                "Arch": "PV64"
-            },
-            "m1.xlarge": {
-                "Arch": "PV64"
-            },
-            "m2.xlarge": {
-                "Arch": "PV64"
-            },
-            "m2.2xlarge": {
-                "Arch": "PV64"
-            },
-            "m2.4xlarge": {
-                "Arch": "PV64"
-            },
-            "m3.medium": {
-                "Arch": "HVM64"
-            },
-            "m3.large": {
-                "Arch": "HVM64"
-            },
-            "m3.xlarge": {
-                "Arch": "HVM64"
-            },
-            "m3.2xlarge": {
-                "Arch": "HVM64"
-            },
-            "m4.large": {
-                "Arch": "HVM64"
-            },
-            "m4.xlarge": {
-                "Arch": "HVM64"
-            },
-            "m4.2xlarge": {
-                "Arch": "HVM64"
-            },
-            "m4.4xlarge": {
-                "Arch": "HVM64"
-            },
-            "m4.10xlarge": {
-                "Arch": "HVM64"
-            },
-            "c1.medium": {
-                "Arch": "PV64"
-            },
-            "c1.xlarge": {
-                "Arch": "PV64"
-            },
-            "c3.large": {
-                "Arch": "HVM64"
-            },
-            "c3.xlarge": {
-                "Arch": "HVM64"
-            },
-            "c3.2xlarge": {
-                "Arch": "HVM64"
-            },
-            "c3.4xlarge": {
-                "Arch": "HVM64"
-            },
-            "c3.8xlarge": {
-                "Arch": "HVM64"
-            },
-            "c4.large": {
-                "Arch": "HVM64"
-            },
-            "c4.xlarge": {
-                "Arch": "HVM64"
-            },
-            "c4.2xlarge": {
-                "Arch": "HVM64"
-            },
-            "c4.4xlarge": {
-                "Arch": "HVM64"
-            },
-            "c4.8xlarge": {
-                "Arch": "HVM64"
-            },
-            "g2.2xlarge": {
-                "Arch": "HVMG2"
-            },
-            "g2.8xlarge": {
-                "Arch": "HVMG2"
-            },
-            "r3.large": {
-                "Arch": "HVM64"
-            },
-            "r3.xlarge": {
-                "Arch": "HVM64"
-            },
-            "r3.2xlarge": {
-                "Arch": "HVM64"
-            },
-            "r3.4xlarge": {
-                "Arch": "HVM64"
-            },
-            "r3.8xlarge": {
-                "Arch": "HVM64"
-            },
-            "i2.xlarge": {
-                "Arch": "HVM64"
-            },
-            "i2.2xlarge": {
-                "Arch": "HVM64"
-            },
-            "i2.4xlarge": {
-                "Arch": "HVM64"
-            },
-            "i2.8xlarge": {
-                "Arch": "HVM64"
-            },
-            "d2.xlarge": {
-                "Arch": "HVM64"
-            },
-            "d2.2xlarge": {
-                "Arch": "HVM64"
-            },
-            "d2.4xlarge": {
-                "Arch": "HVM64"
-            },
-            "d2.8xlarge": {
-                "Arch": "HVM64"
-            },
-            "hi1.4xlarge": {
-                "Arch": "HVM64"
-            },
-            "hs1.8xlarge": {
-                "Arch": "HVM64"
-            },
-            "cr1.8xlarge": {
-                "Arch": "HVM64"
-            },
-            "cc2.8xlarge": {
-                "Arch": "HVM64"
-            }
-        },
         "SubnetConfig": {
             "VPC": {
                 "CIDR": "10.10.0.0/16"
@@ -481,179 +167,6 @@
             },
             "PublicC": {
                 "CIDR": "10.10.3.0/24"
-            }
-        },
-        "AWSInstanceType2NATArch": {
-            "t1.micro": {
-                "Arch": "NATPV64"
-            },
-            "t2.nano": {
-                "Arch": "NATHVM64"
-            },
-            "t2.micro": {
-                "Arch": "NATHVM64"
-            },
-            "t2.small": {
-                "Arch": "NATHVM64"
-            },
-            "t2.medium": {
-                "Arch": "NATHVM64"
-            },
-            "t2.large": {
-                "Arch": "NATHVM64"
-            },
-            "m1.small": {
-                "Arch": "NATPV64"
-            },
-            "m1.medium": {
-                "Arch": "NATPV64"
-            },
-            "m1.large": {
-                "Arch": "NATPV64"
-            },
-            "m1.xlarge": {
-                "Arch": "NATPV64"
-            },
-            "m2.xlarge": {
-                "Arch": "NATPV64"
-            },
-            "m2.2xlarge": {
-                "Arch": "NATPV64"
-            },
-            "m2.4xlarge": {
-                "Arch": "NATPV64"
-            },
-            "m3.medium": {
-                "Arch": "NATHVM64"
-            },
-            "m3.large": {
-                "Arch": "NATHVM64"
-            },
-            "m3.xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "m3.2xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "m4.large": {
-                "Arch": "NATHVM64"
-            },
-            "m4.xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "m4.2xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "m4.4xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "m4.10xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "c1.medium": {
-                "Arch": "NATPV64"
-            },
-            "c1.xlarge": {
-                "Arch": "NATPV64"
-            },
-            "c3.large": {
-                "Arch": "NATHVM64"
-            },
-            "c3.xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "c3.2xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "c3.4xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "c3.8xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "c4.large": {
-                "Arch": "NATHVM64"
-            },
-            "c4.xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "c4.2xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "c4.4xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "c4.8xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "g2.2xlarge": {
-                "Arch": "NATHVMG2"
-            },
-            "g2.8xlarge": {
-                "Arch": "NATHVMG2"
-            },
-            "r3.large": {
-                "Arch": "NATHVM64"
-            },
-            "r3.xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "r3.2xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "r3.4xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "r3.8xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "i2.xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "i2.2xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "i2.4xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "i2.8xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "d2.xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "d2.2xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "d2.4xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "d2.8xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "hi1.4xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "hs1.8xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "cr1.8xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "cc2.8xlarge": {
-                "Arch": "NATHVM64"
-            }
-        },
-        "AWSRegionArch2AMI": {
-            "us-east-1": {
-                "PV64": "ami-036de34578cbfa625",
-                "HVM64": "ami-047a51fa27710816e",
-                "HVMG2": "ami-087435bc474caa2c4"
-            },
-            "us-west-2": {
-                "PV64": "ami-07ce23ee168db0386",
-                "HVM64": "ami-027e033da7800f292",
-                "HVMG2": "ami-0e999cbd62129e3b1"
             }
         }
     },
@@ -764,9 +277,7 @@
                 "AllocatedStorage": {
                     "Ref": "RDSMYSQLStorage"
                 },
-                "DBInstanceClass": {
-                    "Ref": "RDSMYSQLInstanceClass"
-                },
+                "DBInstanceClass": "db.t2.small",
                 "Engine": "MySQL",
                 "EngineVersion": "5.7",
                 "DBSubnetGroupName": {
@@ -794,9 +305,7 @@
                 "AllocatedStorage": {
                     "Ref": "FedoraRDSMYSQLStorage"
                 },
-                "DBInstanceClass": {
-                    "Ref": "FedoraRDSMYSQLInstanceClass"
-                },
+                "DBInstanceClass": "db.t2.small",
                 "Engine": "MySQL",
                 "EngineVersion": "5.7",
                 "DBSubnetGroupName": {
@@ -908,26 +417,8 @@
                 "IamInstanceProfile": {
                     "Ref": "InstanceRoleInstanceProfile"
                 },
-                "ImageId": {
-                    "Fn::FindInMap": [
-                        "AWSRegionArch2AMI",
-                        {
-                            "Ref": "AWS::Region"
-                        },
-                        {
-                            "Fn::FindInMap": [
-                                "AWSInstanceType2Arch",
-                                {
-                                    "Ref": "DataInstanceType"
-                                },
-                                "Arch"
-                            ]
-                        }
-                    ]
-                },
-                "InstanceType": {
-                    "Ref": "DataInstanceType"
-                },
+                "ImageId": "ami-047a51fa27710816e",
+                "InstanceType": "t2.medium",
                 "NetworkInterfaces": [
                     {
                         "GroupSet": [
@@ -1056,23 +547,8 @@
                 "IamInstanceProfile": {
                     "Ref": "InstanceRoleInstanceProfile"
                 },
-                "ImageId": {
-                    "Fn::FindInMap": [
-                        "AWSRegionArch2AMI",
-                        {
-                            "Ref": "AWS::Region"
-                        },
-                        {
-                            "Fn::FindInMap": [
-                                "AWSInstanceType2Arch",
-                                {
-                                    "Ref": "WebInstanceType"
-                                },
-                                "Arch"
-                            ]
-                        }
-                    ]
-                },
+                "InstanceType": "t2.medium",
+                "ImageId": "ami-047a51fa27710816e",
                 "NetworkInterfaces": [
                     {
                         "GroupSet": [
@@ -1088,9 +564,6 @@
                         }
                     }
                 ],
-                "InstanceType": {
-                    "Ref": "DataInstanceType"
-                },
                 "KeyName": {
                     "Ref": "KeyName"
                 },

--- a/ams.new_app.json
+++ b/ams.new_app.json
@@ -300,7 +300,12 @@
             "Default": "0.0.0.0/0",
             "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
             "ConstraintDescription": "must be a valid IP CIDR range of the form x.x.x.x/x."
-        }
+        },
+        "ServerName": {
+            "Description": "Name of the server used in Apache configuration and SSL",
+            "Default": "ams.wgbh.org",
+            "Type": "String"
+        },
     },
     "Mappings": {
         "AWSInstanceType2Arch": {
@@ -646,89 +651,9 @@
                 "HVMG2": "ami-087435bc474caa2c4"
             },
             "us-west-2": {
-                "PV64": "ami-7f77b31f",
-                "HVM64": "ami-f2d3638a",
-                "HVMG2": "ami-ee15a196"
-            },
-            "us-west-1": {
-                "PV64": "ami-a2490dc2",
-                "HVM64": "ami-824c4ee2",
-                "HVMG2": "ami-0da4a46d"
-            },
-            "eu-west-1": {
-                "PV64": "ami-4cdd453f",
-                "HVM64": "ami-d834aba1",
-                "HVMG2": "ami-af8013d6"
-            },
-            "eu-west-2": {
-                "PV64": "NOT_SUPPORTED",
-                "HVM64": "ami-403e2524",
-                "HVMG2": "NOT_SUPPORTED"
-            },
-            "eu-west-3": {
-                "PV64": "NOT_SUPPORTED",
-                "HVM64": "ami-8ee056f3",
-                "HVMG2": "NOT_SUPPORTED"
-            },
-            "eu-central-1": {
-                "PV64": "ami-6527cf0a",
-                "HVM64": "ami-5652ce39",
-                "HVMG2": "ami-1d58ca72"
-            },
-            "ap-northeast-1": {
-                "PV64": "ami-3e42b65f",
-                "HVM64": "ami-ceafcba8",
-                "HVMG2": "ami-edfd658b"
-            },
-            "ap-northeast-2": {
-                "PV64": "NOT_SUPPORTED",
-                "HVM64": "ami-863090e8",
-                "HVMG2": "NOT_SUPPORTED"
-            },
-            "ap-northeast-3": {
-                "PV64": "NOT_SUPPORTED",
-                "HVM64": "ami-83444afe",
-                "HVMG2": "NOT_SUPPORTED"
-            },
-            "ap-southeast-1": {
-                "PV64": "ami-df9e4cbc",
-                "HVM64": "ami-68097514",
-                "HVMG2": "ami-c06013bc"
-            },
-            "ap-southeast-2": {
-                "PV64": "ami-63351d00",
-                "HVM64": "ami-942dd1f6",
-                "HVMG2": "ami-85ef12e7"
-            },
-            "ap-south-1": {
-                "PV64": "NOT_SUPPORTED",
-                "HVM64": "ami-531a4c3c",
-                "HVMG2": "ami-411e492e"
-            },
-            "us-east-2": {
-                "PV64": "NOT_SUPPORTED",
-                "HVM64": "ami-f63b1193",
-                "HVMG2": "NOT_SUPPORTED"
-            },
-            "ca-central-1": {
-                "PV64": "NOT_SUPPORTED",
-                "HVM64": "ami-a954d1cd",
-                "HVMG2": "NOT_SUPPORTED"
-            },
-            "sa-east-1": {
-                "PV64": "ami-1ad34676",
-                "HVM64": "ami-84175ae8",
-                "HVMG2": "NOT_SUPPORTED"
-            },
-            "cn-north-1": {
-                "PV64": "ami-77559f1a",
-                "HVM64": "ami-cb19c4a6",
-                "HVMG2": "NOT_SUPPORTED"
-            },
-            "cn-northwest-1": {
-                "PV64": "ami-80707be2",
-                "HVM64": "ami-3e60745c",
-                "HVMG2": "NOT_SUPPORTED"
+                "PV64": "ami-07ce23ee168db0386",
+                "HVM64": "ami-027e033da7800f292",
+                "HVMG2": "ami-0e999cbd62129e3b1"
             }
         }
     },
@@ -1428,7 +1353,7 @@
                                 "' >> /etc/profile\n",
                                 "echo '\n",
                                 "<VirtualHost _default_:*>\n",
-                                "    ServerName ams.wgbh.org\n",
+                                "ServerName ", { "Ref": "ServerName" }, "\n",
                                 "\n",
                                 "    # Tell Apache and Passenger where your apps public directory is\n",
                                 "    DocumentRoot /var/www/ams/public\n",

--- a/ams.restore_from_snapshot.json
+++ b/ams.restore_from_snapshot.json
@@ -300,7 +300,7 @@
         "RDSDB": {
             "Type": "AWS::RDS::DBInstance",
             "Properties": {
-                "DBSnapshotIdentifier": "arn:aws:rds:us-east-1:127946490116:snapshot:rails-db-ams-stack-restore",
+                "DBSnapshotIdentifier": "arn:aws:rds:us-east-1:127946490116:snapshot:rds:ar1o0zfbqoqn6bb-2021-03-31-03-36",
                 "AllocatedStorage": {
                     "Ref": "RDSMYSQLStorage"
                 },
@@ -323,14 +323,17 @@
                 "MasterUserPassword": {
                     "Ref": "DBPassword"
                 },
-                "MultiAZ": "false"
+                "MultiAZ": "false",
+                "DBParameterGroupName": {
+                    "Ref":  "RDSDBParamGroup"
+                },
             },
             "DeletionPolicy": "Snapshot"
         },
         "FedoraRDSDB": {
             "Type": "AWS::RDS::DBInstance",
             "Properties": {
-                "DBSnapshotIdentifier": "arn:aws:rds:us-east-1:127946490116:snapshot:fedora-db-ams-stack-restore",
+                "DBSnapshotIdentifier": "arn:aws:rds:us-east-1:127946490116:snapshot:rds:afol96fmjnyaq1-2021-03-30-05-09",
                 "AllocatedStorage": {
                     "Ref": "FedoraRDSMYSQLStorage"
                 },
@@ -353,9 +356,32 @@
                 "MasterUserPassword": {
                     "Ref": "FedoraDBPassword"
                 },
-                "MultiAZ": "false"
+                "MultiAZ": "false",
+                "DBParameterGroupName": {
+                    "Ref":  "FedoraRDSDBParamGroup"
+                }
             },
             "DeletionPolicy": "Snapshot"
+        },
+        "RDSDBParamGroup": {
+            "Type": "AWS::RDS::DBParameterGroup",
+            "Properties": {
+                "Family": "MySQL5.5",
+                "Description": "ParameterGroup for RDSDB",
+                "Parameters": {
+                    "max_allowed_packet": "67108864",
+                },
+            },
+        },
+        "FedoraRDSDBParamGroup": {
+            "Type": "AWS::RDS::DBParameterGroup",
+            "Properties": {
+                "Family": "MySQL5.7",
+                "Description": "ParameterGroup for RDSDB",
+                "Parameters": {
+                    "max_allowed_packet": "67108864",
+                },
+            },
         },
         "CacheSubnetGroup": {
             "Type": "AWS::ElastiCache::SubnetGroup",
@@ -448,8 +474,8 @@
                 "IamInstanceProfile": {
                     "Ref": "InstanceRoleInstanceProfile"
                 },
-                "InstanceType": "t2.medium",
                 "ImageId": "ami-047a51fa27710816e",
+                "InstanceType": "t2.medium",
                 "NetworkInterfaces": [
                     {
                         "GroupSet": [
@@ -543,7 +569,7 @@
                                 },
                                 "/opt/solr/bin/init.d/solr restart\n",
                                 "\n",
-                                "chkconfig tomcat7 on\n",
+                                "chkconfig tomcat on\n",
                                 "chkconfig solr on\n",
                                 "/opt/aws/bin/cfn-signal -e 0",
                                 "\n"
@@ -558,7 +584,7 @@
                 }
             }
         },
-        "WebInstance": {
+                "WebInstance": {
             "Type": "AWS::EC2::Instance",
             "DependsOn": "RDSDB",
             "Properties": {
@@ -857,7 +883,7 @@
                                 "' >> /etc/profile\n",
                                 "echo '\n",
                                 "<VirtualHost _default_:*>\n",
-                                "    ServerName ams.wgbh.org\n",
+                                "ServerName ", { "Ref": "ServerName" }, "\n",
                                 "\n",
                                 "    # Tell Apache and Passenger where your apps public directory is\n",
                                 "    DocumentRoot /var/www/ams/public\n",

--- a/ams.restore_from_snapshot.json
+++ b/ams.restore_from_snapshot.json
@@ -154,136 +154,12 @@
             "MaxLength": "41",
             "ConstraintDescription": "must contain only alphanumeric characters, underscores, or dashes."
         },
-        "WebInstanceType": {
-            "Description": "WebServer EC2 instance type",
-            "Type": "String",
-            "Default": "t2.medium",
-            "AllowedValues": [
-                "t1.micro",
-                "t2.nano",
-                "t2.micro",
-                "t2.small",
-                "t2.medium",
-                "t2.large",
-                "m1.small",
-                "m1.medium",
-                "m1.large",
-                "m1.xlarge",
-                "m2.xlarge",
-                "m2.2xlarge",
-                "m2.4xlarge",
-                "m3.medium",
-                "m3.large",
-                "m3.xlarge",
-                "m3.2xlarge",
-                "m4.large",
-                "m4.xlarge",
-                "m4.2xlarge",
-                "m4.4xlarge",
-                "m4.10xlarge",
-                "c1.medium",
-                "c1.xlarge",
-                "c3.large",
-                "c3.xlarge",
-                "c3.2xlarge",
-                "c3.4xlarge",
-                "c3.8xlarge",
-                "c4.large",
-                "c4.xlarge",
-                "c4.2xlarge",
-                "c4.4xlarge",
-                "c4.8xlarge",
-                "g2.2xlarge",
-                "g2.8xlarge",
-                "r3.large",
-                "r3.xlarge",
-                "r3.2xlarge",
-                "r3.4xlarge",
-                "r3.8xlarge",
-                "i2.xlarge",
-                "i2.2xlarge",
-                "i2.4xlarge",
-                "i2.8xlarge",
-                "d2.xlarge",
-                "d2.2xlarge",
-                "d2.4xlarge",
-                "d2.8xlarge",
-                "hi1.4xlarge",
-                "hs1.8xlarge",
-                "cr1.8xlarge",
-                "cc2.8xlarge",
-                "cg1.4xlarge"
-            ],
-            "ConstraintDescription": "must be a valid EC2 instance type."
-        },
         "WebInstanceVolumeSize": {
             "Description": "Size of the EBS volume if attached",
             "Type": "Number",
             "Default": "8",
             "MinValue": "1",
             "MaxValue": "1000"
-        },
-        "DataInstanceType": {
-            "Description": "Data EC2 instance type",
-            "Type": "String",
-            "Default": "t2.medium",
-            "AllowedValues": [
-                "t1.micro",
-                "t2.nano",
-                "t2.micro",
-                "t2.small",
-                "t2.medium",
-                "t2.large",
-                "m1.small",
-                "m1.medium",
-                "m1.large",
-                "m1.xlarge",
-                "m2.xlarge",
-                "m2.2xlarge",
-                "m2.4xlarge",
-                "m3.medium",
-                "m3.large",
-                "m3.xlarge",
-                "m3.2xlarge",
-                "m4.large",
-                "m4.xlarge",
-                "m4.2xlarge",
-                "m4.4xlarge",
-                "m4.10xlarge",
-                "c1.medium",
-                "c1.xlarge",
-                "c3.large",
-                "c3.xlarge",
-                "c3.2xlarge",
-                "c3.4xlarge",
-                "c3.8xlarge",
-                "c4.large",
-                "c4.xlarge",
-                "c4.2xlarge",
-                "c4.4xlarge",
-                "c4.8xlarge",
-                "g2.2xlarge",
-                "g2.8xlarge",
-                "r3.large",
-                "r3.xlarge",
-                "r3.2xlarge",
-                "r3.4xlarge",
-                "r3.8xlarge",
-                "i2.xlarge",
-                "i2.2xlarge",
-                "i2.4xlarge",
-                "i2.8xlarge",
-                "d2.xlarge",
-                "d2.2xlarge",
-                "d2.4xlarge",
-                "d2.8xlarge",
-                "hi1.4xlarge",
-                "hs1.8xlarge",
-                "cr1.8xlarge",
-                "cc2.8xlarge",
-                "cg1.4xlarge"
-            ],
-            "ConstraintDescription": "must be a valid EC2 instance type."
         },
         "DataInstanceVolumeSize": {
             "Description": "Size of the EBS volume if attached",
@@ -308,167 +184,6 @@
         },
     },
     "Mappings": {
-        "AWSInstanceType2Arch": {
-            "t1.micro": {
-                "Arch": "PV64"
-            },
-            "t2.nano": {
-                "Arch": "HVM64"
-            },
-            "t2.micro": {
-                "Arch": "HVM64"
-            },
-            "t2.small": {
-                "Arch": "HVM64"
-            },
-            "t2.medium": {
-                "Arch": "HVM64"
-            },
-            "t2.large": {
-                "Arch": "HVM64"
-            },
-            "m1.small": {
-                "Arch": "PV64"
-            },
-            "m1.medium": {
-                "Arch": "PV64"
-            },
-            "m1.large": {
-                "Arch": "PV64"
-            },
-            "m1.xlarge": {
-                "Arch": "PV64"
-            },
-            "m2.xlarge": {
-                "Arch": "PV64"
-            },
-            "m2.2xlarge": {
-                "Arch": "PV64"
-            },
-            "m2.4xlarge": {
-                "Arch": "PV64"
-            },
-            "m3.medium": {
-                "Arch": "HVM64"
-            },
-            "m3.large": {
-                "Arch": "HVM64"
-            },
-            "m3.xlarge": {
-                "Arch": "HVM64"
-            },
-            "m3.2xlarge": {
-                "Arch": "HVM64"
-            },
-            "m4.large": {
-                "Arch": "HVM64"
-            },
-            "m4.xlarge": {
-                "Arch": "HVM64"
-            },
-            "m4.2xlarge": {
-                "Arch": "HVM64"
-            },
-            "m4.4xlarge": {
-                "Arch": "HVM64"
-            },
-            "m4.10xlarge": {
-                "Arch": "HVM64"
-            },
-            "c1.medium": {
-                "Arch": "PV64"
-            },
-            "c1.xlarge": {
-                "Arch": "PV64"
-            },
-            "c3.large": {
-                "Arch": "HVM64"
-            },
-            "c3.xlarge": {
-                "Arch": "HVM64"
-            },
-            "c3.2xlarge": {
-                "Arch": "HVM64"
-            },
-            "c3.4xlarge": {
-                "Arch": "HVM64"
-            },
-            "c3.8xlarge": {
-                "Arch": "HVM64"
-            },
-            "c4.large": {
-                "Arch": "HVM64"
-            },
-            "c4.xlarge": {
-                "Arch": "HVM64"
-            },
-            "c4.2xlarge": {
-                "Arch": "HVM64"
-            },
-            "c4.4xlarge": {
-                "Arch": "HVM64"
-            },
-            "c4.8xlarge": {
-                "Arch": "HVM64"
-            },
-            "g2.2xlarge": {
-                "Arch": "HVMG2"
-            },
-            "g2.8xlarge": {
-                "Arch": "HVMG2"
-            },
-            "r3.large": {
-                "Arch": "HVM64"
-            },
-            "r3.xlarge": {
-                "Arch": "HVM64"
-            },
-            "r3.2xlarge": {
-                "Arch": "HVM64"
-            },
-            "r3.4xlarge": {
-                "Arch": "HVM64"
-            },
-            "r3.8xlarge": {
-                "Arch": "HVM64"
-            },
-            "i2.xlarge": {
-                "Arch": "HVM64"
-            },
-            "i2.2xlarge": {
-                "Arch": "HVM64"
-            },
-            "i2.4xlarge": {
-                "Arch": "HVM64"
-            },
-            "i2.8xlarge": {
-                "Arch": "HVM64"
-            },
-            "d2.xlarge": {
-                "Arch": "HVM64"
-            },
-            "d2.2xlarge": {
-                "Arch": "HVM64"
-            },
-            "d2.4xlarge": {
-                "Arch": "HVM64"
-            },
-            "d2.8xlarge": {
-                "Arch": "HVM64"
-            },
-            "hi1.4xlarge": {
-                "Arch": "HVM64"
-            },
-            "hs1.8xlarge": {
-                "Arch": "HVM64"
-            },
-            "cr1.8xlarge": {
-                "Arch": "HVM64"
-            },
-            "cc2.8xlarge": {
-                "Arch": "HVM64"
-            }
-        },
         "SubnetConfig": {
             "VPC": {
                 "CIDR": "10.10.0.0/16"
@@ -481,179 +196,6 @@
             },
             "PublicC": {
                 "CIDR": "10.10.3.0/24"
-            }
-        },
-        "AWSInstanceType2NATArch": {
-            "t1.micro": {
-                "Arch": "NATPV64"
-            },
-            "t2.nano": {
-                "Arch": "NATHVM64"
-            },
-            "t2.micro": {
-                "Arch": "NATHVM64"
-            },
-            "t2.small": {
-                "Arch": "NATHVM64"
-            },
-            "t2.medium": {
-                "Arch": "NATHVM64"
-            },
-            "t2.large": {
-                "Arch": "NATHVM64"
-            },
-            "m1.small": {
-                "Arch": "NATPV64"
-            },
-            "m1.medium": {
-                "Arch": "NATPV64"
-            },
-            "m1.large": {
-                "Arch": "NATPV64"
-            },
-            "m1.xlarge": {
-                "Arch": "NATPV64"
-            },
-            "m2.xlarge": {
-                "Arch": "NATPV64"
-            },
-            "m2.2xlarge": {
-                "Arch": "NATPV64"
-            },
-            "m2.4xlarge": {
-                "Arch": "NATPV64"
-            },
-            "m3.medium": {
-                "Arch": "NATHVM64"
-            },
-            "m3.large": {
-                "Arch": "NATHVM64"
-            },
-            "m3.xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "m3.2xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "m4.large": {
-                "Arch": "NATHVM64"
-            },
-            "m4.xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "m4.2xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "m4.4xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "m4.10xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "c1.medium": {
-                "Arch": "NATPV64"
-            },
-            "c1.xlarge": {
-                "Arch": "NATPV64"
-            },
-            "c3.large": {
-                "Arch": "NATHVM64"
-            },
-            "c3.xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "c3.2xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "c3.4xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "c3.8xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "c4.large": {
-                "Arch": "NATHVM64"
-            },
-            "c4.xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "c4.2xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "c4.4xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "c4.8xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "g2.2xlarge": {
-                "Arch": "NATHVMG2"
-            },
-            "g2.8xlarge": {
-                "Arch": "NATHVMG2"
-            },
-            "r3.large": {
-                "Arch": "NATHVM64"
-            },
-            "r3.xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "r3.2xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "r3.4xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "r3.8xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "i2.xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "i2.2xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "i2.4xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "i2.8xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "d2.xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "d2.2xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "d2.4xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "d2.8xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "hi1.4xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "hs1.8xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "cr1.8xlarge": {
-                "Arch": "NATHVM64"
-            },
-            "cc2.8xlarge": {
-                "Arch": "NATHVM64"
-            }
-        },
-        "AWSRegionArch2AMI": {
-            "us-east-1": {
-                "PV64": "ami-036de34578cbfa625",
-                "HVM64": "ami-047a51fa27710816e",
-                "HVMG2": "ami-087435bc474caa2c4"
-            },
-            "us-west-2": {
-                "PV64": "ami-07ce23ee168db0386",
-                "HVM64": "ami-027e033da7800f292",
-                "HVMG2": "ami-0e999cbd62129e3b1"
             }
         }
     },
@@ -758,7 +300,7 @@
         "RDSDB": {
             "Type": "AWS::RDS::DBInstance",
             "Properties": {
-                "DBSnapshotIdentifier": "REPLACE WITH ARN OF RAILS RDS DB SNAPSHOT",
+                "DBSnapshotIdentifier": "arn:aws:rds:us-east-1:127946490116:snapshot:rails-db-ams-stack-restore",
                 "AllocatedStorage": {
                     "Ref": "RDSMYSQLStorage"
                 },
@@ -766,7 +308,7 @@
                     "Ref": "RDSMYSQLInstanceClass"
                 },
                 "Engine": "MySQL",
-                "EngineVersion": "5.7",
+                "EngineVersion": "5.5",
                 "DBSubnetGroupName": {
                     "Ref": "MyDBSubnetGroup"
                 },
@@ -788,7 +330,7 @@
         "FedoraRDSDB": {
             "Type": "AWS::RDS::DBInstance",
             "Properties": {
-                "DBSnapshotIdentifier": "REPLACE WITH ARN OF FEDORA RDS DB SNAPSHOT",
+                "DBSnapshotIdentifier": "arn:aws:rds:us-east-1:127946490116:snapshot:fedora-db-ams-stack-restore",
                 "AllocatedStorage": {
                     "Ref": "FedoraRDSMYSQLStorage"
                 },
@@ -891,7 +433,6 @@
             "DependsOn": "FedoraRDSDB",
             "Properties": {
                 "DisableApiTermination": "false",
-                "ImageId": "REPLACE WITH IMAGE ID OF AMI CREATED FROM SNAPSHOT OF DataInstance EC2 ROOT VOLUME",
                 "BlockDeviceMappings": [
                     {
                         "DeviceName": "/dev/xvda",
@@ -907,9 +448,8 @@
                 "IamInstanceProfile": {
                     "Ref": "InstanceRoleInstanceProfile"
                 },
-                "InstanceType": {
-                    "Ref": "DataInstanceType"
-                },
+                "InstanceType": "t2.medium",
+                "ImageId": "ami-047a51fa27710816e",
                 "NetworkInterfaces": [
                     {
                         "GroupSet": [
@@ -1038,23 +578,8 @@
                 "IamInstanceProfile": {
                     "Ref": "InstanceRoleInstanceProfile"
                 },
-                "ImageId": {
-                    "Fn::FindInMap": [
-                        "AWSRegionArch2AMI",
-                        {
-                            "Ref": "AWS::Region"
-                        },
-                        {
-                            "Fn::FindInMap": [
-                                "AWSInstanceType2Arch",
-                                {
-                                    "Ref": "WebInstanceType"
-                                },
-                                "Arch"
-                            ]
-                        }
-                    ]
-                },
+                "InstanceType": "t2.medium",
+                "ImageId": "ami-047a51fa27710816e",
                 "NetworkInterfaces": [
                     {
                         "GroupSet": [
@@ -1070,9 +595,6 @@
                         }
                     }
                 ],
-                "InstanceType": {
-                    "Ref": "DataInstanceType"
-                },
                 "KeyName": {
                     "Ref": "KeyName"
                 },

--- a/ams.restore_from_snapshot.json
+++ b/ams.restore_from_snapshot.json
@@ -300,7 +300,12 @@
             "Default": "0.0.0.0/0",
             "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
             "ConstraintDescription": "must be a valid IP CIDR range of the form x.x.x.x/x."
-        }
+        },
+        "ServerName": {
+            "Description": "Name of the server used in Apache configuration and SSL",
+            "Default": "ams.wgbh.org",
+            "Type": "String"
+        },
     },
     "Mappings": {
         "AWSInstanceType2Arch": {
@@ -641,94 +646,14 @@
         },
         "AWSRegionArch2AMI": {
             "us-east-1": {
-                "PV64": "ami-2a69aa47",
-                "HVM64": "ami-97785bed",
-                "HVMG2": "ami-0a6e3770"
+                "PV64": "ami-036de34578cbfa625",
+                "HVM64": "ami-047a51fa27710816e",
+                "HVMG2": "ami-087435bc474caa2c4"
             },
             "us-west-2": {
-                "PV64": "ami-7f77b31f",
-                "HVM64": "ami-f2d3638a",
-                "HVMG2": "ami-ee15a196"
-            },
-            "us-west-1": {
-                "PV64": "ami-a2490dc2",
-                "HVM64": "ami-824c4ee2",
-                "HVMG2": "ami-0da4a46d"
-            },
-            "eu-west-1": {
-                "PV64": "ami-4cdd453f",
-                "HVM64": "ami-d834aba1",
-                "HVMG2": "ami-af8013d6"
-            },
-            "eu-west-2": {
-                "PV64": "NOT_SUPPORTED",
-                "HVM64": "ami-403e2524",
-                "HVMG2": "NOT_SUPPORTED"
-            },
-            "eu-west-3": {
-                "PV64": "NOT_SUPPORTED",
-                "HVM64": "ami-8ee056f3",
-                "HVMG2": "NOT_SUPPORTED"
-            },
-            "eu-central-1": {
-                "PV64": "ami-6527cf0a",
-                "HVM64": "ami-5652ce39",
-                "HVMG2": "ami-1d58ca72"
-            },
-            "ap-northeast-1": {
-                "PV64": "ami-3e42b65f",
-                "HVM64": "ami-ceafcba8",
-                "HVMG2": "ami-edfd658b"
-            },
-            "ap-northeast-2": {
-                "PV64": "NOT_SUPPORTED",
-                "HVM64": "ami-863090e8",
-                "HVMG2": "NOT_SUPPORTED"
-            },
-            "ap-northeast-3": {
-                "PV64": "NOT_SUPPORTED",
-                "HVM64": "ami-83444afe",
-                "HVMG2": "NOT_SUPPORTED"
-            },
-            "ap-southeast-1": {
-                "PV64": "ami-df9e4cbc",
-                "HVM64": "ami-68097514",
-                "HVMG2": "ami-c06013bc"
-            },
-            "ap-southeast-2": {
-                "PV64": "ami-63351d00",
-                "HVM64": "ami-942dd1f6",
-                "HVMG2": "ami-85ef12e7"
-            },
-            "ap-south-1": {
-                "PV64": "NOT_SUPPORTED",
-                "HVM64": "ami-531a4c3c",
-                "HVMG2": "ami-411e492e"
-            },
-            "us-east-2": {
-                "PV64": "NOT_SUPPORTED",
-                "HVM64": "ami-f63b1193",
-                "HVMG2": "NOT_SUPPORTED"
-            },
-            "ca-central-1": {
-                "PV64": "NOT_SUPPORTED",
-                "HVM64": "ami-a954d1cd",
-                "HVMG2": "NOT_SUPPORTED"
-            },
-            "sa-east-1": {
-                "PV64": "ami-1ad34676",
-                "HVM64": "ami-84175ae8",
-                "HVMG2": "NOT_SUPPORTED"
-            },
-            "cn-north-1": {
-                "PV64": "ami-77559f1a",
-                "HVM64": "ami-cb19c4a6",
-                "HVMG2": "NOT_SUPPORTED"
-            },
-            "cn-northwest-1": {
-                "PV64": "ami-80707be2",
-                "HVM64": "ami-3e60745c",
-                "HVMG2": "NOT_SUPPORTED"
+                "PV64": "ami-07ce23ee168db0386",
+                "HVM64": "ami-027e033da7800f292",
+                "HVMG2": "ami-0e999cbd62129e3b1"
             }
         }
     },
@@ -841,7 +766,7 @@
                     "Ref": "RDSMYSQLInstanceClass"
                 },
                 "Engine": "MySQL",
-                "EngineVersion": "5.5",
+                "EngineVersion": "5.7",
                 "DBSubnetGroupName": {
                     "Ref": "MyDBSubnetGroup"
                 },
@@ -871,7 +796,7 @@
                     "Ref": "FedoraRDSMYSQLInstanceClass"
                 },
                 "Engine": "MySQL",
-                "EngineVersion": "5.5",
+                "EngineVersion": "5.7",
                 "DBSubnetGroupName": {
                     "Ref": "MyDBSubnetGroup"
                 },
@@ -1045,18 +970,18 @@
                                 "yum -y install mysql-devel\n",
                                 "\n",
                                 "#Install Fedora\n",
-                                "yum -y install tomcat7\n",
+                                "yum -y install tomcat\n",
                                 "echo 'JAVA_OPTS=\"${JAVA_OPTS} -Dfcrepo.home=/mnt/fedora-data\"' >> /etc/sysconfig/tomcat7\n",
                                 "mkdir /mnt/fedora-data\n",
                                 "chown tomcat:tomcat /mnt/fedora-data/\n",
                                 "wget https://github.com/fcrepo4/fcrepo4/releases/download/fcrepo-4.7.5/fcrepo-webapp-4.7.5.war\n",
-                                "cp fcrepo-webapp-4.7.5.war /var/lib/tomcat7/webapps/\n",
-                                "echo 'fcrepo.home=/mnt/fedora-data' >> /etc/tomcat7/catalina.properties\n",
-                                "echo 'fcrepo.mysql.host=", { "Fn::GetAtt": ["FedoraRDSDB", "Endpoint.Address" ] },"' >> /etc/tomcat7/catalina.properties\n",
-                                "echo 'fcrepo.mysql.username=", { "Ref": "FedoraDBUser" }, "' >> /etc/tomcat7/catalina.properties\n",
-                                "echo 'fcrepo.mysql.password=", { "Ref": "FedoraDBPassword" }, "' >> /etc/tomcat7/catalina.properties\n",
-                                "echo 'fcrepo.modeshape.configuration=file:/var/lib/tomcat7/webapps/fcrepo-webapp-4.7.5/WEB-INF/classes/config/jdbc-mysql/repository.json' >> /etc/tomcat7/catalina.properties\n",
-                                "service tomcat7 restart\n",
+                                "cp fcrepo-webapp-4.7.5.war /var/lib/tomcat/webapps/\n",
+                                "echo 'fcrepo.home=/mnt/fedora-data' >> /etc/tomcat/catalina.properties\n",
+                                "echo 'fcrepo.mysql.host=", { "Fn::GetAtt": ["FedoraRDSDB", "Endpoint.Address" ] },"' >> /etc/tomcat/catalina.properties\n",
+                                "echo 'fcrepo.mysql.username=", { "Ref": "FedoraDBUser" }, "' >> /etc/tomcat/catalina.properties\n",
+                                "echo 'fcrepo.mysql.password=", { "Ref": "FedoraDBPassword" }, "' >> /etc/tomcat/catalina.properties\n",
+                                "echo 'fcrepo.modeshape.configuration=file:/var/lib/tomcat/webapps/fcrepo-webapp-4.7.5/WEB-INF/classes/config/jdbc-mysql/repository.json' >> /etc/tomcat/catalina.properties\n",
+                                "service tomcat restart\n",
                                 "wget http://archive.apache.org/dist/lucene/solr/6.5.0/solr-6.5.0.tgz\n",
                                 "tar xzf solr-6.5.0.tgz solr-6.5.0/bin/install_solr_service.sh --strip-components=2\n",
                                 "./install_solr_service.sh solr-6.5.0.tgz\n",
@@ -1249,7 +1174,7 @@
                                 "echo 'export PATH=$PATH:/opt/fits-1.0.5/' >> /etc/profile\n",
                                 "#Install Apache\n",
                                 "yum install -y curl-devel nano sqlite-devel libyaml-devel   \n",
-                                "yum install -y httpd24 httpd24-devel\n",
+                                "yum install -y httpd httpd-devel links\n",
                                 "su - ec2-user -c 'gem install passenger'\n",
                                 "su - ec2-user -c 'passenger-install-apache2-module --auto'\n",
                                 "su - ec2-user -c 'passenger-install-apache2-module --snippet > /tmp/passenger.conf'\n",
@@ -1427,10 +1352,21 @@
                                 "\n",
                                 "#Configure Apache\n",
                                 "usermod -a -G apache ec2-user\n",
-                                "service httpd restart\n",
+                                "systemctl restart httpd\n",
                                 "\n",
                                 "chkconfig httpd on\n",
                                 "\n",
+                                "#Prepare SSL\n",
+                                "yum install -y mod_ssl\n",
+                                "cd /etc/pki/tls/certs\n",
+                                "./make-dummy-cert localhost.crt\n",
+                                "sed -e '/SSLCertificateKeyFile/s/^#*/#/' -i /etc/httpd/conf.d/ssl.conf\n",
+                                "systemctl restart httpd\n",
+                                "cd /home/ec2-user\n",
+                                "wget -r --no-parent -A 'epel-release-*.rpm' https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/e/\n",
+                                "rpm -Uvh dl.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-*.rpm\n",
+                                "yum-config-manager --enable epel*\n",
+                                "yum install -y certbot python2-certbot-apache\n",
                                 "#Install code deploy\n",
                                 "mkdir /tmp/codedeploy\n",
                                 "cd /tmp/codedeploy\n",
@@ -1837,6 +1773,12 @@
                         "IpProtocol": "tcp",
                         "FromPort": "80",
                         "ToPort": "80",
+                        "CidrIp": "0.0.0.0/0"
+                    },
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": "443",
+                        "ToPort": "443",
                         "CidrIp": "0.0.0.0/0"
                     },
                     {

--- a/ams.restore_from_snapshot.json
+++ b/ams.restore_from_snapshot.json
@@ -300,7 +300,7 @@
         "RDSDB": {
             "Type": "AWS::RDS::DBInstance",
             "Properties": {
-                "DBSnapshotIdentifier": "arn:aws:rds:us-east-1:127946490116:snapshot:rds:ar1o0zfbqoqn6bb-2021-03-31-03-36",
+                "DBSnapshotIdentifier": "REPLACE WITH ARN OF RAILS RDS DB SNAPSHOT",
                 "AllocatedStorage": {
                     "Ref": "RDSMYSQLStorage"
                 },
@@ -308,7 +308,7 @@
                     "Ref": "RDSMYSQLInstanceClass"
                 },
                 "Engine": "MySQL",
-                "EngineVersion": "5.5",
+                "EngineVersion": "5.6",
                 "DBSubnetGroupName": {
                     "Ref": "MyDBSubnetGroup"
                 },
@@ -333,7 +333,7 @@
         "FedoraRDSDB": {
             "Type": "AWS::RDS::DBInstance",
             "Properties": {
-                "DBSnapshotIdentifier": "arn:aws:rds:us-east-1:127946490116:snapshot:rds:afol96fmjnyaq1-2021-03-30-05-09",
+                "DBSnapshotIdentifier": "REPLACE WITH ARN OF FEDORA RDS DB SNAPSHOT",
                 "AllocatedStorage": {
                     "Ref": "FedoraRDSMYSQLStorage"
                 },

--- a/ams.restore_from_snapshot.json
+++ b/ams.restore_from_snapshot.json
@@ -366,7 +366,7 @@
         "RDSDBParamGroup": {
             "Type": "AWS::RDS::DBParameterGroup",
             "Properties": {
-                "Family": "MySQL5.5",
+                "Family": "MySQL5.6",
                 "Description": "ParameterGroup for RDSDB",
                 "Parameters": {
                     "max_allowed_packet": "67108864",
@@ -584,7 +584,7 @@
                 }
             }
         },
-                "WebInstance": {
+        "WebInstance": {
             "Type": "AWS::EC2::Instance",
             "DependsOn": "RDSDB",
             "Properties": {


### PR DESCRIPTION
This PR:
- Updates process to restore an instance of AMS2
- Updates our EC2 instance choice and provisioning scripts to use an Amazon Linux 2 AMI
- Adds SSL support to provisioning script
- Updates README
- Adds a ParamGroup for our DBs that increases the default max_allowed_packet param